### PR TITLE
商品一覧表示機能を実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new]
 
   def index
-    @item = Item.new
+    @items = Item.order("created_at DESC")
   end
 
   def new

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,5 +1,10 @@
 class Item < ApplicationRecord
   extend ActiveHash::Associations::ActiveRecordExtensions
+  belongs_to :category
+  belongs_to :condition
+  belongs_to :shipping_charge
+  belongs_to :area
+  belongs_to :shipping_date
   belongs_to :user
   has_one_attached :image
 

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,11 +126,11 @@
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+    <% @items.each do |item| %>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag @item.image, class: "item-img" if @item.image.attached? %>
+          <%= image_tag item.image, class: "item-img" if item.image.attached? %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>
@@ -141,22 +141,21 @@
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= @item.title %>
+            <%= item.title %>
           </h3>
           <div class='item-price'>
-            <span><%= @item.price %>円<br><%= @item.shipping_charge_id %></span>
+            <span><%= item.price %>円<br><%= item.shipping_charge.name %></span>
             <div class='star-btn'>
-              <%= image_tag @item.image, class:"star-icon" if @item.image.attached? %>
+              <%= image_tag item.image, class:"star-icon" if item.image.attached? %>
               <span class='star-count'>0</span>
             </div>
           </div>
         </div>
         <% end %>
       </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
+    <% end %>
+    
+      <% if @items.length == 0 %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -174,8 +173,8 @@
         </div>
         <% end %>
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+      <% end %>
+
     </ul>
   </div>
   <%# /商品一覧 %>


### PR DESCRIPTION
# What
商品と、必要な情報を一覧ページに表示

# Why
出品した商品を一覧表示するため
- 商品のデータがない場合は、ダミー商品が表示されている動画
https://gyazo.com/319ef42c35542105d93c316daec4ca44
- 商品のデータがある場合は、商品が一覧で表示されている動画
https://gyazo.com/94e96edae41944a5a5cb644592803949